### PR TITLE
[Jer1s] week2 (수정)

### DIFF
--- a/style.css
+++ b/style.css
@@ -87,6 +87,7 @@ body {
   inset: 0;
   height: 6rem;
   background-color: rgba(240, 246, 255, 0.5);
+  z-index: 1;
 }
 
 .navbar-container .logo {
@@ -180,6 +181,10 @@ body {
     font-size: 4rem;
   }
 
+  .content-frame:first-child {
+    margin-top: 0;
+  }
+
   .site-header .header-content {
     display: block;
     width: 75rem;
@@ -196,58 +201,51 @@ body {
     width: 62.375rem;
     height: 28.125rem;
     margin: 6.25rem auto;
-  }
-
-  .content-frame:first-child {
-    margin-top: 0;
-  }
-
-  .content-frame.right-side img{
-    float: right;
-    height: 100%;
-  }
-
-  .content-frame.left-side img{
-    float: left;
-    height: 100%;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
   }
 
   .content-frame .title {
-    display: inline-block;
     font-size: 3rem;
-    margin: 0;
-    width: 18rem;
+    width: 18.2rem;
   }
 
   .content-frame .description {
-    display: inline-block;
-    margin: 0;
     color: var(--description);
     line-height: 150%;
-    width: 18rem;
+    width: 18.2rem;
   }
 
-  /* 세로 정렬을 absolute position으로 해결했는데 범용적이지 않음 */
   .content-frame.right-side .title {
-    position: absolute;
-    top: 8rem;
+    margin: auto 0 0.3rem 0;
+  }
+
+  .content-frame.right-side img {
+    width: 100%;
+    grid-column: 2 / 3;
+    grid-row: 1 / 3;
   }
 
   .content-frame.right-side .description {
-    position: absolute;
-    top: 15.625rem;
+    margin: 0.3rem 0 auto 0;
+    font-weight: 500;
   }
 
   .content-frame.left-side .title {
-    position: absolute;
-    top: 8rem;
-    right: 0;
+    margin: auto 0 0.3rem auto;
+    font-size: 3rem;
+  }
+
+  .content-frame.left-side img {
+    width: 100%;
+    grid-column: 1 / 2;
+    grid-row: 1 / 3;
   }
 
   .content-frame.left-side .description {
-    position: absolute;
-    top: 15.625rem;
-    right: 0;
+    margin: 0.3rem 0 auto auto;
+    font-weight: 500;
   }
 }
 
@@ -291,58 +289,59 @@ body {
     width: 43.75rem;
     height: 19.6875rem;
     margin: 6.25rem auto;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
   }
 
   .content-frame:first-child {
     margin-top: 0;
   }
 
-  .content-frame.right-side img{
-    float: right;
-    height: 100%;
-  }
-
-  .content-frame.left-side img{
-    float: left;
-    height: 100%;
+  .content-frame img{
+    width: 100%;
   }
   
   .content-frame .title {
-    display: inline-block;
     font-size: 3rem;
-    margin: 0;
-    width: 17.3rem;
+    width: 17.2rem;
   }
 
   .content-frame .description {
-    display: inline-block;
-    margin: 0.625rem 0 0 0;
     color: var(--description);
     line-height: 150%;
-    width: 17.3rem;
+    width: 17.2rem;
   }
 
   .content-frame.right-side .title {
-    position: absolute;
-    top: 3.7rem;
+    margin: auto 0 0.3rem 0;
+  }
+
+  .content-frame.right-side img {
+    width: 100%;
+    grid-column: 2 / 3;
+    grid-row: 1 / 3;
   }
 
   .content-frame.right-side .description {
-    position: absolute;
-    top: 11.5rem;
+    margin: 0.3rem 0 auto 0;
+    font-weight: 500;
   }
 
   .content-frame.left-side .title {
-    position: absolute;
-    top: 3.7rem;
-    right: 0;
+    margin: auto 0 0.3rem auto;
+  }
+
+  .content-frame.left-side img {
+    grid-column: 1 / 2;
+    grid-row: 1 / 3;
   }
 
   .content-frame.left-side .description {
-    position: absolute;
-    top: 11.5rem;
-    right: 0;
+    margin: 0.3rem 0 auto auto;
+    font-weight: 500;
   }
+
   /* site-footer */
   .site-footer .footer {
     padding: 2rem 6.5rem 6.875rem;
@@ -463,6 +462,7 @@ body {
     padding-bottom: 5rem;
     margin: 0;
   }
+
   .content-frame img {
     width: 100%;
     margin: 1.25rem 0 1rem 0;
@@ -500,6 +500,7 @@ body {
   .footer .footer-right {
     margin-left: auto;
   }
+
   .grid-item:nth-child(1) {
     order: 1;
   }


### PR DESCRIPTION
## **(전체 영향) 필수 요구사항**
- 반응형 디자인을 적용해 주세요. (아래는 width를 기준으로 한 분기 지점 입니다.)
  - [x] PC: 1200px 이상
  - [x] tablet: 768px 이상
  - [x] mobile: 375px 이상
  - [x] 375px 미만 사이즈의 디자인은 고려하지 않음
## **(전체 영향) 선택 요구사항**
- [x] 사용자의 브라우저 font-size가 크고 작아짐에 따라 페이지의 요소간 간격, 요소의 크기, font-size 등 모든 크기와 관련된 값이 크고 작아지도록 설정 하세요.

## **(PC) 필수 요구사항**
- PC 사이즈에서 기기의 width가
  - [x] 1920px 이상이면 내부에 있는 요소의 위치는 landing/pc와 동일한 간격을 유지하며 가운데 정렬해야 합니다.
- PC 사이즈에서 기기의 width가
  - [x] 1920px보다 작아질 때, "Linkbrary" 로고의 왼쪽 여백 200px "로그인" 버튼의 오른쪽 여백 200px이 유지되고, 화면의 너비가 작아질수록 두 요소간 거리가 가까워져야 합니다.
- PC 사이즈에서 기기의 width가
  - [x] 1920px보다 작아질 때, 최하단에 있는 "codeit-2023"의 왼쪽 여백 104px과 SNS 아이콘들의 오른쪽 여백 104px을 유지하면서 가운데 있는 Privacy Policy, FAQ 요소와 각각 동일한 간격을 유지하며 가까워져야 합니다.

## **(tablet) 필수 요구사항**
- tablet 사이즈에서 기기의 width가
  - [x] 1199px 에서 작아질 때 “Linkbrary” 로고와 “로그인” 버튼 사이의 간격은 유지하고 좌우 여백이 줄어듭니다.
  - [x] 863px 보다 작아질 때, “Linkbrary” 로고의 왼쪽에 여백 32px, “로그인” 버튼 오른쪽 여백 32px이 최소 여백을 유지할 수 있도록 “Linkbrary” 로고와 “로그인" 버튼의 간격이 가까워지도록 합니다.

## **(mobile) 필수 요구사항**
- [x] mobile 사이즈에서 기기의 width에 관계없이 전체 좌우 여백이 32px을 유지하도록 하고, 이미지 요소의 경우 좌우 여백 32px을 제외하고 이미지가 꽉 찰 수 있도록 width와 height가 원본의 비율대로 커지도록 합니다.
- [x] mobile 사이즈 width가 커지면, Privacy Policy, FAQ가 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 커지도록 하세요.
- [x] mobile 사이즈에서만 제목, 이미지, 설명의 순서대로 배치해 주세요.

## **(mobile) 선택 요구사항**
- [x] mobile 사이즈에서만 제목, 이미지, 설명의 순서대로 배치해 주세요.
<br>

## 주요 변경사항

- 반응형으로 PC, tablet, mobile page design
- 배경색 불투명도 50%인 네비게이션 바 상단 고정
- 브라우저의 font-size에 비례한 단위를 사용하여 시안에 맞게 margin, padding, size 등을 조정
- 모바일 페이지에서의 main section의 img 위치를 제목과 본문 사이로 이동

<br>

## 멘토에게

- 비효율적이거나 불필요한 코드가 있는지 전체적으로 확인해주세요.