### PR TITLE
[샐리] - Week2 추가 PR

### DIFF
--- a/Linkbrary.css
+++ b/Linkbrary.css
@@ -143,7 +143,7 @@ footer {
   padding: 3.2rem 10.4rem 0;
 }
 
-#copywright {
+#copyright {
   font-family: 'Arial';
   font-size: 1.6rem;
   font-weight: 400;
@@ -355,5 +355,7 @@ footer {
     height: 16rem;
     padding: 3.2rem;
     margin-top: 4rem;
+    position: relative;
   }
+
 }

--- a/Linkbrary.css
+++ b/Linkbrary.css
@@ -313,6 +313,19 @@ footer {
   }
 
   /* section_2 */
+  .card {
+    flex-direction: column;
+  }
+
+  .reverseCard {
+    flex-direction: column-reverse;
+  }
+
+  .cardText {
+    width: 100%;
+    margin: 0;
+  }
+
   .title2 {
     font-size: 2.4rem;
     line-height: 2.9rem;
@@ -324,8 +337,8 @@ footer {
     line-height: 150%;
   }
 
-  .card {
-    flex-direction: column;
+  .description br{
+    display: none;
   }
 
   .cardImage {
@@ -340,4 +353,3 @@ footer {
   }
 
 }
-

--- a/Linkbrary.css
+++ b/Linkbrary.css
@@ -130,6 +130,7 @@ header {
 .cardImage {
   width: 55rem;
   height: 45rem;
+  margin-top: 2.4rem;
 }
 
 
@@ -271,6 +272,7 @@ footer {
 
   .section_2 {
     padding: 0 3.2rem;
+    margin: 0;
   }
 
   /* header */
@@ -315,6 +317,8 @@ footer {
   /* section_2 */
   .card {
     flex-direction: column;
+    margin: 0;
+    padding: 4rem 0;
   }
 
   .reverseCard {
@@ -350,6 +354,6 @@ footer {
   footer {
     height: 16rem;
     padding: 3.2rem;
+    margin-top: 4rem;
   }
-
 }

--- a/Linkbrary.css
+++ b/Linkbrary.css
@@ -358,4 +358,9 @@ footer {
     position: relative;
   }
 
+  #copyright {
+    position: absolute;
+    bottom: 3.2rem;
+    left: 3.2rem;
+  }
 }

--- a/Linkbrary.css
+++ b/Linkbrary.css
@@ -6,8 +6,12 @@
 }
 
 html {
-  width: 100%;
   margin: 0 auto;
+  font-size: 62.5%;
+}
+
+body {
+  width: 100%;
 }
 
 /* 모든 a태그에 밑줄 없앰 */
@@ -19,8 +23,8 @@ a {
 header {
   background-color: #f0f6ff;
   width: 100%;
-  height: 94px;
-  padding: 0 200px;
+  height: 9.4rem;
+  padding: 0 20rem;
   position: sticky;
   top: 0;
   left: 0;
@@ -31,58 +35,59 @@ header {
 
 /* Linkbrary 로고 사이즈 조절 */
 .logo {
-  height: 24px;
+  width: auto;
+  height: 2.4rem;
 }
 
 /* 로그인, 링크추가하기를 같은 class button */
 .button {
   display: block;
   background: linear-gradient(90.99deg, #6d6afe 0.12%, #6ae3fe 101.84%);
-  height: 53px;
-  border-radius: 8px;
-  padding: 16px 0;
+  height: 5.3rem;
+  border-radius: 0.8rem;
+  padding: 1.6rem 0;
   color: #f5f5f5;
   text-align: center;
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: 600;
-  line-height: 21px;
+  line-height: 2.1rem;
 }
 
 /* 로그인 button 너비 */
 #signin {
-  width: 128px;
+  width: 12.8rem;
 }
 
 /* 링크추가하기 button 너비 */
 #addLink {
-  width: 350px;
-  margin: 40px auto 0;
+  width: 35rem;
+  margin: 4rem auto 0;
 }
 
 /* 파란 배경의 section_1 */
 .section_1 {
   background-color: #f0f6ff;
   height: auto;
-  padding-top: 70px;
+  padding-top: 7rem;
 }
 
 .title1 {
-  font-size: 64px;
+  font-size: 6.4rem;
   font-weight: 700;
   text-align: center;
-  line-height: 80px;
+  line-height: 8rem;
 }
 
 #image1 {
   display: block;
-  width: 1200px;
-  height: 590px;
-  margin: 40px auto 0;
+  width: 120rem;
+  height: 59rem;
+  margin: 4rem auto 0;
 }
 
 /* 하얀 배경의 section_2 */
 .section_2 {
-  margin: 120px 0 170px;
+  margin: 12rem 0 17rem;
   height: auto;
 }
 
@@ -90,82 +95,82 @@ header {
   height: auto;
   display: flex;
   justify-content: center;
-  margin: 100px 0;
+  margin: 10rem 0;
 }
 
 .title2 {
-  font-size: 48px;
+  font-size: 4.8rem;
   font-weight: 700;
-  line-height: 57px;
+  line-height: 5.7rem;
 }
 
 .description {
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 500;
   color: #6b6b6b;
-  line-height: 24px;
+  line-height: 2.4rem;
 }
 
 .cardText {
-  width: 291px;
+  width: 29.1rem;
   margin: auto 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 1rem;
 }
 
 .rightText {
-  margin-right: 157px;
+  margin-right: 15.7rem;
 }
 
 .leftText {
-  margin-left: 157px;
+  margin-left: 15.7rem;
 }
 
 .cardImage {
-  width: 550px;
-  height: 450px;
+  width: 55rem;
+  height: 45rem;
 }
 
 
 /* footer 영역 */
 footer {
   background-color: black;
-  height: 160px;
+  height: 16rem;
   display: flex;
   justify-content: space-between;
-  padding: 32px 104px 0;
+  padding: 3.2rem 10.4rem 0;
 }
 
 #copywright {
   font-family: 'Arial';
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 400;
-  line-height: 18px;
+  line-height: 1.8rem;
   color: #676767;
 }
 
 .bottomLinks {
   display: flex;
-  gap: 30px;
+  gap: 3rem;
   align-items: flex-start;
 }
 
 .bottomLink {
   font-family: 'Arial';
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 400;
   color: #cfcfcf;
 }
 
 .snsIcons {
   display: flex;
-  gap: 13px;
+  gap: 1.3rem;
   align-items: flex-start;
 }
 
 .snsIcon {
-  height: 20px;
+  height: 2rem;
 }
 
 
@@ -209,12 +214,12 @@ footer {
 @media (max-width: 1199px) {
   header {
     justify-content: center;
-    gap: 538px;
+    gap: 53.8rem;
     padding: 0;
   }
 
   .section_1 {
-    padding-top: 40px;
+    padding-top: 4rem;
   }
 
   #lineChange {
@@ -222,36 +227,36 @@ footer {
   }
 
   #image1 {
-    width: 698px;
-    height: 343px;
+    width: 69.8rem;
+    height: 34.3rem;
   }
 
   .rightText {
-    margin-right: 51px;
+    margin-right: 5.1rem;
   }
 
   .leftText {
-    margin-left: 51px;
+    margin-left: 5.1rem;
   }
 
   .section_2 {
-    margin-top: 80px;
+    margin-top: 8rem;
   }
 
   .card {
-    margin-top: 80px;
+    margin-top: 8rem;
   }
 
   .cardImage {
-    width: 385px;
-    height: 315px;
+    width: 38.5rem;
+    height: 31.5rem;
   }
 
 }
 
 @media (max-width: 863px) {
   header {
-    padding: 0 32px;
+    padding: 0 3.2rem;
     justify-content: space-between;
     gap: 0;
   }
@@ -261,61 +266,61 @@ footer {
 @media (max-width: 767px) {
   /* main 내부 padding 조절 */
   .section_1 {
-    padding: 28px 32px 0;
+    padding: 2.8rem 3.2rem 0;
   }
 
   .section_2 {
-    padding: 0 32px;
+    padding: 0 3.2rem;
   }
 
   /* header */
   header {
-    height: 63px;
+    height: 6.3rem;
   }
   
   .logo {
-    width: 77.58px;
-    height: 14px;
+    width: 7.758rem;
+    height: auto;
   }
 
   /* 로그인 링크추가 버튼 */
   .button {
-    height: 37px;
-    font-size: 14px;
-    line-height: 17px;
-    padding: 10px 0;
+    height: 3.7rem;
+    font-size: 1.4rem;
+    line-height: 1.7rem;
+    padding: 1rem 0;
   }
 
   #signin {
-    width: 80px;
+    width: 8rem;
   }
 
   #addLink {
-    width: 200px;
-    margin-top: 24px;
+    width: 20rem;
+    margin-top: 2.4rem;
   }
 
   /* section_1 */
   .title1 {
-    font-size: 32px;
-    line-height: 42px;
+    font-size: 3.2rem;
+    line-height: 4.2rem;
   }
 
   #image1 {
     width: 100%;
     height: auto;
-    margin-top: 24px;
+    margin-top: 2.4rem;
   }
 
   /* section_2 */
   .title2 {
-    font-size: 24px;
-    line-height: 29px;
-    letter-spacing: -0.3px;
+    font-size: 2.4rem;
+    line-height: 2.9rem;
+    letter-spacing: -0.03rem;
   }
 
   .description {
-    font-size: 15px;
+    font-size: 1.5rem;
     line-height: 150%;
   }
 
@@ -330,8 +335,8 @@ footer {
 
   /* Mobile footer */
   footer {
-    height: 160px;
-    padding: 32px;
+    height: 16rem;
+    padding: 3.2rem;
   }
 
 }

--- a/Linkbrary.css
+++ b/Linkbrary.css
@@ -259,8 +259,80 @@ footer {
 
 /* mobile 사이즈 */
 @media (max-width: 767px) {
-  main {
+  /* main 내부 padding 조절 */
+  .section_1 {
+    padding: 28px 32px 0;
+  }
+
+  .section_2 {
     padding: 0 32px;
   }
+
+  /* header */
+  header {
+    height: 63px;
+  }
+  
+  .logo {
+    width: 77.58px;
+    height: 14px;
+  }
+
+  /* 로그인 링크추가 버튼 */
+  .button {
+    height: 37px;
+    font-size: 14px;
+    line-height: 17px;
+    padding: 10px 0;
+  }
+
+  #signin {
+    width: 80px;
+  }
+
+  #addLink {
+    width: 200px;
+    margin-top: 24px;
+  }
+
+  /* section_1 */
+  .title1 {
+    font-size: 32px;
+    line-height: 42px;
+  }
+
+  #image1 {
+    width: 100%;
+    height: auto;
+    margin-top: 24px;
+  }
+
+  /* section_2 */
+  .title2 {
+    font-size: 24px;
+    line-height: 29px;
+    letter-spacing: -0.3px;
+  }
+
+  .description {
+    font-size: 15px;
+    line-height: 150%;
+  }
+
+  .card {
+    flex-direction: column;
+  }
+
+  .cardImage {
+    width: 100%;
+    height: auto;
+  }
+
+  /* Mobile footer */
+  footer {
+    height: 160px;
+    padding: 32px;
+  }
+
 }
 

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
       </section>
     </main>
     <footer>
-      <div id="copywright">©codeit-2023</div>
+      <div id="copyright">©codeit-2023</div>
       <div class="bottomLinks">
         <a class="bottomLink" href="/privacy">Privacy Policy</a>
         <a class="bottomLink" href="/faq">FAQ</a>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         <div class="card">
           <div class="cardText rightText">
             <h2 class="title2">
-              <span id="gradient2">원하는 링크</span>를<br>
+              <p><span id="gradient2">원하는 링크</span>를</p>
               저장하세요
             </h2>
             <p class="description">

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         <div class="card">
           <div class="cardText rightText">
             <h2 class="title2">
-              <p><span id="gradient2">원하는 링크</span>를</p>
+              <span id="gradient2">원하는 링크</span>를
               저장하세요
             </h2>
             <p class="description">
@@ -73,23 +73,23 @@
           </div>
           <img class="cardImage" src="images/image2.png">
         </div>
-        <div class="card">
+        <div class="card reverseCard">
           <img class="cardImage" src="images/image3.png">
           <div class="cardText leftText">
             <h2 class="title2">
-              링크를 폴더로<br>
+              링크를 폴더로
               <span id="gradient3">관리</span>하세요
             </h2>
             <p class="description">
               나만의 폴더를 무제한으로 만들고<br>
-              다양하게 활용할 수 있어요.
+              다양하게 활용할 수 있습니다.
             </p>
           </div>
         </div>
         <div class="card">
           <div class="cardText rightText">
             <h2 class="title2">
-              저장한 링크를<br>
+              저장한 링크를
               <span id="gradient4">공유</span>해 보세요.
             </h2>
             <p class="description">
@@ -100,11 +100,11 @@
           </div>
           <img class="cardImage" src="images/image4.png">
         </div>
-        <div class="card">
+        <div class="card reverseCard">
           <img class="cardImage" src="images/image5.png">
           <div class="cardText leftText">
             <h2 class="title2">
-              저장한 링크를<br>
+              저장한 링크를
               <span id="gradient5">검색</span>해 보세요
             </h2>
             <p class="description">

--- a/index.html
+++ b/index.html
@@ -30,9 +30,9 @@
       content="세상의 모든 정보를 쉽게 저장하고 관리해보세요"
     >
     <link
-    rel=“stylesheet”
-    type=“text/css”
-    href=“https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard-dynamic-subset.css”
+    rel="stylesheet"
+    type="text/css"
+    href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard-dynamic-subset.css"
     >
     <link rel="stylesheet" href="Linkbrary.css">
   </head>


### PR DESCRIPTION
### 2주차 추가PR
1. 코드 리뷰 후 수정은 2개 PR 합쳐서 3주차 때 모두 반영하겠습니다!
2. Class 말고 id도 많이 활용을 했는데 안 좋은 방식일까요 아님 개인적인 스타일인 걸까요?,, 또 안 쓰일 것 같은 건 거의 id로 뒀었거든요,,
3. 사용자의 브라우저 font-size에 따라 달라지게 하는 것에 단위 rem 썼는데 제대로 한 걸까요?
미디어 쿼리 max-width는 px 단위를 써야 하는 건가요?,,
4. 일단 모바일 선택사항에서 제목-이미지-설명 순 배치는 포기했습니다ㅠ 코드를 뜯어고치지 않는 이상 힘들 것 같더라구요ㅠㅠ 제 판단(뜯어고쳐야 선택사항 구현할 수 있겠다)이 맞는걸까요 아님 지금 상태에서도 할 수 있는 쉬운 방법이 있는 걸까요?,, (position absolute로 설명을 내려도 보고 했는데 잘 안 되더라고요ㅠ)
5. commit 단위?를 지금 정도로 유지하면 될까요 아님 너무 많거나 적거나 어떤가요?,, 뭔가 하나를 완료하고 넘어간게 아니라 이거 건들다 잘 안 되면 다음거 넘어가서 해보고 그래서,, 하핳


### 필수 요구사항

- [x] 반응형 디자인을 적용해 주세요. (아래는 width를 기준으로 한 분기 지점 입니다.)

  - [x] PC: 1200px 이상
  - [x] tablet: 768px 이상 ~ 1199px 이하
  - [x] mobile: 375px 이상 ~ 767px 이하
        (375px 미만 사이즈의 디자인은 고려하지 않음)

- [x] 아래로 스크롤 해도 “Linkbrary”와 “로그인" 버튼이 들어있는 gnb 영역이 최상단에 고정되어 볼 수 있도록 하세요.

- [x] pc, tablet 사이지의 이미지는 고정값을 사용하고, mobile 사이즈는 좌우 여백 32px을 제외한 이미지 영역이 꽉 찰 수 있도록 해주세요. 이때 가로가 커지는 비율에 맞춰 세로도 커지면 됩니다.

pc 사이즈에서 기기의 width가

- [x] 1920px 보다 작아질 때, “Linkbrary” 로고의 왼쪽 여백 200px “로그인" 버튼의 오른쪽 여백 200px이 유지되고, 화면의 너비가 작아질수록 두 요소간 거리가 가까워져야 합니다.
- [x] 1920px 보다 작아질 때, 최하단에 있는 “codeit-2023”의 왼쪽 여백 104px과 SNS 아이콘들의 오른쪽 여백 104px을 유지하면서 가운데 있는 Privacy Policy, FAQ 요소와 각각 동일한 간격을 유지하며 가까워져야 합니다.
- [x] 1920px 이상이면 내부에 있는 요소의 위치는 landing/pc 와 동일한 간격을 유지하며 가운데 정렬해야 합니다.

tablet 사이즈에서 기기의 width가

- [x] 1199px 에서 작아질 때 “Linkbrary” 로고와 “로그인” 버튼 사이의 간격은 유지하고 좌우 여백이 줄어듭니다.
- [x] 863px 보다 작아질 때, “Linkbrary” 로고의 왼쪽에 여백 32px, “로그인” 버튼 오른쪽 여백 32px이 최소 여백을 유지할 수 있도록 “Linkbrary” 로고와 “로그인" 버튼의 간격이 가까워지도록 합니다.

mobile 사이즈에서

- [x] 기기의 width에 관계없이 전체 좌우 여백이 32px을 유지하도록 하고, 이미지 요소의 경우 좌우 여백 32px을 제외하고 이미지가 꽉 찰 수 있도록 width와 height가 원본의 비율대로 커지도록 합니다.
- [x] width가 커지면, Privacy Policy, FAQ가 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 커지도록 하세요.

<br>

### 선택 요구사항

- [x] 사용자의 브라우저 font-size가 크고 작아짐에 따라 페이지의 요소간 간격, 요소의 크기, font-size 등 모든 크기와 관련된 값이 크고 작아지도록 설정 하세요.
- [ ] mobile 사이즈에서만 제목, 이미지, 설명의 순서대로 배치해 주세요.